### PR TITLE
Windows build opened the console when not needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ add_executable(miraya
 	setupwizard.h setupwizard.cpp setupwizard.ui
 )
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+	set_property(TARGET miraya PROPERTY WIN32_EXECUTABLE true)
+endif()
+
 target_link_libraries(miraya PRIVATE Qt6::Core)
 target_link_libraries(miraya PRIVATE Qt6::Widgets)
 target_link_libraries(miraya PRIVATE Qt6::WebSockets)


### PR DESCRIPTION
Windows programs do not usually open a cmd prompt whenever they are opened. in version `1.0.0-alpha.1`, this was an issue.