### PR TITLE
Names with spaces could not connect to irc

### DIFF
--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -107,12 +107,17 @@ void Preferences::saveSettings()
   settings.setValue("twitch/botNick", ui->twitchBotNickLineEdit->text().toLower());
   settings.setValue("twitch/oauth", ui->twitchBotOAuthLineEdit->text());
   settings.setValue("twitch/channel", ui->twitchChannelLineEdit->text().toLower());
+
   settings.setValue("gosumemory/ip", ui->gosumemoryIpLineEdit->text());
   settings.setValue("gosumemory/port", ui->gosumemoryPortLineEdit->text());
-  settings.setValue("osuirc/nick", ui->osuIrcNicknameLineEdit->text());
+
+	// Spaces need to be replaced by underscores.
+	// https://osu.ppy.sh/wiki/en/Community/Internet_Relay_Chat#connection
+  settings.setValue("osuirc/nick", ui->osuIrcNicknameLineEdit->text().replace(' ', '_'));
   settings.setValue("osuirc/password", ui->osuIrcPasswordLineEdit->text());
   settings.setValue("osuirc/server", ui->osuIrcServerLineEdit->text());
   settings.setValue("osuirc/port", ui->osuIrcPortLineEdit->text());
+
   settings.setValue("theme/darkMode", ui->themesDarkRadio->isChecked());
 }
 

--- a/src/setupwizard/setupwizard.cpp
+++ b/src/setupwizard/setupwizard.cpp
@@ -95,6 +95,10 @@ QJsonObject SetupWizard::getOsuircData()
 	QString osuircServer = ui->osuircServerLineEdit->text();
 	int osuircPort = ui->osuircPortLineEdit->text().toInt();
 
+	// Spaces need to be replaced by underscores.
+	// https://osu.ppy.sh/wiki/en/Community/Internet_Relay_Chat#connection
+	osuircNick.replace(' ', '_');
+
 	QJsonObject osuircData = QJsonObject{
 		{"nick", osuircNick},
 		{"password", osuircPassword},


### PR DESCRIPTION
As stated in the [wiki page](https://osu.ppy.sh/wiki/en/Community/Internet_Relay_Chat#connection), when connecting to osu! irc spaces need to be replaced by underscores.