### PR TITLE
[BUG] Chat autoscoll did not work

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -154,6 +154,7 @@ void MainWindow::onTwitchClientMessageReceived(TwitchDataWrapper message)
 	item->setSizeHint(label->size()); // Set the size hint based on the label's size
 	ui->twitchChat->addItem(item);
 	ui->twitchChat->setItemWidget(item, label);
+	ui->twitchChat->scrollToBottom();
 }
 
 


### PR DESCRIPTION
At some point in v1.1.0, auto-scroll was removed... idk what happened