### PR TITLE
Win executable with icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,15 @@ set(CMAKE_AUTORCC ON)
 
 # Add the executable
 if (WIN32)
-	add_executable(miraya WIN32 ${SOURCES})
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/icon.o
+		COMMAND windres icon.rc -o ${CMAKE_CURRENT_BINARY_DIR}/icon.o
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		DEPENDS icon.rc
+	)
+	add_custom_target(icon ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/icon.o)
+
+	add_executable(miraya WIN32 ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/icon.o)
 	if (CMAKE_BUILD_TYPE STREQUAL "Release")
 		set_property(TARGET miraya PROPERTY WIN32_EXECUTABLE true)
 	endif()

--- a/icon.rc
+++ b/icon.rc
@@ -1,0 +1,1 @@
+IDI_ICON1   ICON    DISCARDABLE     "./resources/logo/logo.ico"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
 	app.setOrganizationName("miraya");
 	app.setOrganizationDomain("github.com/MirayaProject");
 	app.setApplicationName("bot");
-	app.setApplicationVersion("1.2.0-alpha.3");
+	app.setApplicationVersion("1.2.0-alpha.4");
 	app.setWindowIcon(QIcon(":/resources/logo/logo.png"));
 	MainWindow mw;
 	mw.show();


### PR DESCRIPTION
## Before
![image](https://github.com/MirayaProject/miraya/assets/31241607/2d6ae680-dea5-45cf-b6e0-f6d5d6262ef9)
## After
![image](https://github.com/MirayaProject/miraya/assets/31241607/ba9b83e8-84e1-4c4e-83ee-3e6a7680a36c)
Icon has been included!
Thanks @arancinosbarazzino for the heads up and [this gist for the implementation](https://gist.github.com/Niakr1s/749a88643e154320768e5972c80347cb)

Concludes #51 for Windows. Still trying to figure out what to do with Linux.